### PR TITLE
Partner descriptions: Fix for grammatical errors/misspellings/formulation inconsistencies

### DIFF
--- a/pages/partners.de.md
+++ b/pages/partners.de.md
@@ -24,7 +24,7 @@ sections:
   - title: Enterprise Datenintegration
     subsections:
       - title: Attunity
-        description: Unternehmen auf der ganzen Welt setzen Attunity ein, um einen größeren Nutzen aus mehr Daten zu ziehen und dabei auch noch Zeit und Kosten einzusparen. Unsere Auswahl an Softwareprodukten beschleunigt die Datenübertragung und -verfügbarkeit, automatisiert die Datenbereitschaft für Analysen und optimiert das Datenmanagement auf clevere Weise. Mit der Unterstützung der verschiedensten Arten von Integration für die vielfältigsten IT-Plattformen nimmt Attunity eine Vorreiterrolle bei der Verfügbarkeit heterogener Daten ein.
+        description: Unternehmen auf der ganzen Welt setzen Attunity ein, um einen grösseren Nutzen aus mehr Daten zu ziehen und dabei auch noch Zeit und Kosten einzusparen – Datenübertragung und -verfügbarkeit  werden beschleunigt, Datenbereitschaft für Analysen automatisiert und das Datenmanagement auf clevere Weise optimiert. Mit der Unterstützung der verschiedensten Arten von Integration für die vielfältigsten IT-Plattformen nimmt Attunity eine Vorreiterrolle bei der Verfügbarkeit heterogener Daten ein.
         logos:
           - img: /assets/img/partners/attunity.png
             url: http://www.attunity.com
@@ -32,7 +32,7 @@ sections:
   - title: Datenaufbereitung, Analytik & Visualisierung
     subsections:
       - title: Trifacta
-        description: Trifactas Mission ist es, die Produktivität für Data Analysten auf einen neuen Level zu bringen. Trifacta konzentriert sich den Bottleneck im Data Lifecycles, das Daten-Wrangling intuitiver und effizienter gestalten.
+        description: Trifactas Mission ist es, die Produktivität für Data Analysten auf einen neuen Level zu bringen, indem sie den Bottleneck im Data Lifecycle – das Daten-Wrangling – intuitiver und effizienter gestalten. 
         logos:
           - img: /assets/img/partners/trifacta.png
             url: http://www.trifacta.com
@@ -40,12 +40,12 @@ sections:
   - title: NoSQL & Real Time Technologie
     subsections:
       - title: Confluent
-        description: Event-Streaming-Plattform, die von den ursprünglichen Entwicklern von Apache Kafka® entwickelt wurde. "Confluent hat eine Open-Source-Plattform für Event-Streaming geschaffen und diese als Unternehmenslösung neu interpretiert. Das Streaming von Daten als Ereignisse ermöglicht völlig neue Möglichkeiten zur Lösung von Problemen mit hoher Skalierung."
+        description: Confluent ist eine Event-Streaming-Plattform, die von den ursprünglichen Entwicklern von Apache Kafka® open-source entwickelt und als Unternehmenslösung neu interpretiert wurde. Das Streaming von Daten als Ereignisse ermöglicht völlig neue Möglichkeiten zur Lösung von Problemen mit hoher Skalierung.
         logos:
           - img: /assets/img/partners/confluent.png
             url: http://www.confluent.io
-      - title: Neo4J
-        description: Weltweit führende Grafikdatenbank mit nativer Grafikspeicherung und -verarbeitung. Das Property Graph Modell und die Cypher-Abfragesprache erleichtern das Verständnis.
+      - title: Neo4j
+        description: Neo4j ist die weltweit führende Grafikdatenbank mit nativer Grafikspeicherung und -verarbeitung, die mit ihrem Property Graph-Modell und der eigenen Cypher-Abfragesprache für ein einfaches Verständnis bei jedem Graph-Problem sorgt.
         logos:
           - img: /assets/img/partners/neo4j.png
             url: http://www.neo4j.com
@@ -53,29 +53,29 @@ sections:
   - title: Industriepartner
     subsections:
       - title: T-Systems
-        description: T-Systems bietet in der Schweiz eine Hadoop Cloud Lösung an. Mit dieser Lösung können Unternehmen ein bare-metal Hadoop Cluster in einem PaaS Angebot erhalten, welches neben optimaler Anbindung an das Kundennetzwerk auch garantiert, dass Ihre Daten nur auf dedizierter Hardware für Sie in der Schweiz liegt. Scigility und T-Systems arbeiten eng zusammen, um diese PaaS optimal für Sie einzusetzen.
+        description: T-Systems bietet in der Schweiz eine Hadoop Cloud Lösung an. Mit dieser Lösung können Unternehmen ein bare-metal Hadoop Cluster in einem PaaS Angebot erhalten, welches neben optimaler Anbindung an das Kundennetzwerk auch garantiert, dass die Daten nur auf dedizierter Hardware in der Schweiz liegt. Scigility und T-Systems arbeiten eng zusammen, um diese PaaS optimal einzusetzen.
         logos:
           - img: /assets/img/partners/t-systems.png
             url: http://www.t-systems.com/ch/de
       - title: HP Enterprise
-        description: Hewlett Packard ist seit über 75 Jahren im Bereich Innovationen tätig. HPs umfassendes Portfolio sind Teil einer Innovationsstrategie, die entwickelt wurde, um Organisationen aller Grössen – vom weltweit tätigen Konzern bis hin zum lokalen Startup-Unternehmen – bei der Transformation von traditionellen Technologieplattformen auf IT-Systeme der Zukunft zu unterstützen. Scigility und HP arbeiten gemeinsam um die digitale Transformation bei Kunden optimal voranzubringen.
+        description: Hewlett Packard ist seit über 75 Jahren im Bereich Innovationen tätig. HPs umfassendes Portfolio sind Teil einer Innovationsstrategie, die entwickelt wurde, um Organisationen aller Grössen – vom weltweit tätigen Konzern bis hin zum lokalen Startup-Unternehmen – bei der Transformation von traditionellen Technologieplattformen auf IT-Systeme der Zukunft zu unterstützen. Scigility und HP arbeiten gemeinsam daran, die digitale Transformation bei Kunden optimal voranzubringen.
         logos:
           - img: /assets/img/partners/hpe.png
             url: http://www.hpe.com/de/de/home.html
       - title:  SAP
-        description: Als einer der Marktführer bei Unternehmenssoftware hilft SAP Unternehmen und Organisationen dabei, die schädlichen Auswirkungen von Komplexität zu minimieren, neue Möglichkeiten für Innovation und Wachstum zu schaffen und im Wettbewerb erfolgreich zu sein. Scigility hat sich spezialisiert auf die Integration von SAP HANA und Hadoop Umgebungen. Dabei arbeiten wir mit unseren SAP Partnern SEC1.01 zusammen.
+        description: Als einer der Marktführer bei Unternehmenssoftware hilft SAP Unternehmen und Organisationen dabei, die schädlichen Auswirkungen von Komplexität zu minimieren, neue Möglichkeiten für Innovation und Wachstum zu schaffen und im Wettbewerb erfolgreich zu sein. In Zusammenarbeit mit dem Partner SEC1.01 hat sich Scigility darauf spezialisiert, SAP HANA und Hadoop Umgebungen zu integrieren.
         logos:
           - img: /assets/img/partners/sap.jpg
             url: http://www.sap.ch
           - img: /assets/img/partners/sec101.jpg
             url: http://www.sec101.ch
       - title:  Edorex
-        description: Edorex ist ein Schweizer Solution Integrator. Mit Edorex zusammen erarbeitet Scigility innovative, datengetriebene Lösungen für unsere Kunden.
+        description: Edorex ist ein Schweizer Solution Integrator und arbeitet gemeinsam mit Scigility daran, innovative und datengetriebene Lösungen anzubieten.
         logos:
           - img: /assets/img/partners/edorex.png
             url: http://www.edorex.ch
       - title:  Teradata
-        description: Teradata bietet End-to-End-Data Warehousing Services sowie Lösungen für Big Data Analytics, mit denen Sie zu einem datenbasierten Unternehmen avancieren und so Ihren Umsatz steigern, die Effizienz erhöhen und überzeugende Kundenerfahrungen bewirken können. Scigility arbeitet mit Teradata zusammen um Hadoop, Teradata Data Warehouse und Teradata AsterData bestmöglich zu integrieren.
+        description: Teradata bietet End-to-End-Data Warehousing Services sowie Lösungen für Big Data Analytics und hilft Unternehmen damit, datenbasiert zu agieren, den Umsatz zu steigern, die Effizienz zu erhöhen und überzeugende Kunden-Experience zu erreichen. Scigility arbeitet mit Teradata zusammen um Hadoop, Teradata Data Warehouse und Teradata AsterData bestmöglich zu integrieren.
         logos:
           - img: /assets/img/partners/teradata.jpg
             url: http://www.teradata.ch
@@ -83,7 +83,7 @@ sections:
   - title: Akademie und Forschung
     subsections:
       - title: Exascale Infolab
-        description: Scigility ist überzeugt davon, dass wir unseren Kunden die besten Leistungen anbieten können, wenn wir mit guten Industrie- und Akademie-Partnern zusammenarbeiten. Darum sind wir stets bestrebt auch einen Beitrag in Forschung und Entwicklung von Big Data Technologien zu leisten. Mit dem Exascale Info Lab arbeitet Scigility auf einer täglichen Basis zusammen, damit wir für unsere Kunden immer ein kompetenter Partner bei den neuesten Technologien und Methoden sind.
+        description: Wir sind überzeugt davon, dass wir unseren Kunden nur dann die besten Leistungen anbieten können, wenn wir mit guten Industrie- und Akademie-Partnern zusammenarbeiten. Darum sind wir stets bestrebt, auch einen Beitrag in Forschung und Entwicklung von Big Data Technologien zu leisten. Mit dem Exascale Info Lab arbeiten wir regelmässig zusammen, um auch in Zukunft ein kompetenter Partner mit den den neuesten Technologien und Methoden zu bleiben.
         logos:
           - img: /assets/img/partners/xi.jpg
             url: http://exascale.info

--- a/pages/partners.de.md
+++ b/pages/partners.de.md
@@ -63,7 +63,7 @@ sections:
           - img: /assets/img/partners/hpe.png
             url: http://www.hpe.com/de/de/home.html
       - title:  SAP
-        description: Als einer der Marktführer bei Unternehmenssoftware hilft SAP Unternehmen und Organisationen dabei, die schädlichen Auswirkungen von Komplexität zu minimieren, neue Möglichkeiten für Innovation und Wachstum zu schaffen und im Wettbewerb erfolgreich zu sein. In Zusammenarbeit mit dem Partner SEC1.01 hat sich Scigility darauf spezialisiert, SAP HANA und Hadoop Umgebungen zu integrieren.
+        description: Als einer der Marktführer bei Unternehmenssoftware hilft SAP Unternehmen und Organisationen dabei, die schädlichen Auswirkungen von Komplexität zu minimieren, neue Möglichkeiten für Innovation und Wachstum zu schaffen und im Wettbewerb erfolgreich zu sein. Scigility hat sich darauf spezialisiert, SAP HANA und Hadoop Umgebungen zu integrieren.
         logos:
           - img: /assets/img/partners/sap.jpg
             url: http://www.sap.ch

--- a/pages/partners.en.md
+++ b/pages/partners.en.md
@@ -63,7 +63,7 @@ sections:
           - img: /assets/img/partners/hpe.png
             url: http://www.hpe.com/de/de/home.html
       - title:  SAP
-        description: As one of the market leaders for enterprise software, SAP supports companies and organisations with minimizing the negative impact of system complexity, as well as creating new possibilities of innovation and growth to remain competitive. Working together with partner SEC1.01, Scigility has specialized in the integration of SAP HANA and Hadoop environments.
+        description: As one of the market leaders for enterprise software, SAP supports companies and organisations with minimizing the negative impact of system complexity, as well as creating new possibilities of innovation and growth to remain competitive. Scigility has specialized in the integration of SAP HANA and Hadoop environments.
         logos:
           - img: /assets/img/partners/sap.jpg
             url: http://www.sap.ch

--- a/pages/partners.en.md
+++ b/pages/partners.en.md
@@ -11,12 +11,12 @@ sections:
   - title: Enterprise Data Platform
     subsections:
       - title: Cloudera
-        description: Cloudera Data Platform, combines the best of Hortonworks’ and Cloudera’s open source technologies with Data Platform- and Data Flow-stacks for a modern information platform. Cloudera offer all of the key capabilities of an enterprise data cloud—hybrid and multi-public cloud, multi-function analytics, shared security and governance services (SDX), and open-source platforms with choice of compute and storage. 
+        description: Cloudera Data Platform combines the best of Hortonworks' and Cloudera's open source technologies with Data Platform- and Data Flow-stacks for a modern information platform. Cloudera offer all of the key capabilities of an enterprise data cloud—hybrid and multi-public cloud, multi-function analytics, shared security and governance services (SDX), and open-source platforms with choice of compute and storage. 
         logos:
           - img: /assets/img/partners/cloudera.png
             url: http://www.cloudera.com
       - title: Databricks
-        description: Databricks Unified Analytics Platform, from the original creators of Apache Spark™, unifies data science and engineering across the Machine Learning lifecycle from data preparation, to experimentation and deployment of ML applications.
+        description: Databricks Unified Analytics Platform (from the original creators of Apache Spark™) unifies data science and engineering across the Machine Learning lifecycle - from data preparation to experimentation and deployment of ML applications.
         logos:
           - img: /assets/img/partners/databricks.png
             url: http://www.databricks.com
@@ -24,7 +24,7 @@ sections:
   - title: Enterprise Data Integration
     subsections:
       - title: Attunity
-        description: The Attunity software portfolio accelerates data delivery and availability, automates data readiness for analytics and optimizes data management with intelligence. Attunity is pioneer in heterogeneous data availability, supporting many styles of integration across the industry’s broadest array of platforms and addresses modern databases, data warehouses, SAP, Hadoop and real-time messaging systems such as Kafka, on premises and in the Cloud, as well as legacy mainframe systems.
+        description: The Attunity software portfolio accelerates data delivery and availability, automates data readiness for analytics and optimizes data management with intelligence. Attunity is pioneer in heterogeneous data availability, supporting many styles of integration across the industry's broadest array of platforms and addresses modern databases, data warehouses, SAP, Hadoop and real-time messaging systems such as Kafka, on premises and in the Cloud, as well as legacy mainframe systems.
         logos:
           - img: /assets/img/partners/attunity.png
             url: http://www.attunity.com
@@ -32,7 +32,7 @@ sections:
   - title: Data Preparation, Analytics & Visualisation
     subsections:
       - title: Trifacta
-        description: Trifacta’s mission is to create radical productivity for people who analyze data. We’re deeply focused on solving for the biggest bottleneck in the data lifecycle, data wrangling, by making it more intuitive and efficient for anyone who works with data. 
+        description: Trifacta's mission is to create radical productivity for people who analyze data, solving the biggest bottleneck in the data lifecycle – data wrangling – by making it more intuitive and efficient for anyone who works with data. 
         logos:
           - img: /assets/img/partners/trifacta.png
             url: http://www.trifacta.com
@@ -40,12 +40,12 @@ sections:
   - title: NoSQL & Real Time Technology
     subsections:
       - title: Confluent
-        description: Event streaming platform built by the original creators of Apache Kafka®. "Confluent created an open source event streaming platform and reimagined it as an enterprise solution. Streaming data as events enables completely new ways of solving problems at scale."
+        description: Confluent is an open-source event streaming platform built by the original creators of Apache Kafka® reimagined as an enterprise solution. Streaming data as events enables completely new ways of solving problems at scale."
         logos:
           - img: /assets/img/partners/confluent.png
             url: http://www.confluent.io
-      - title: Neo4J
-        description: World's leading graph database, with native graph storage and processing. Property graph model and Cypher query language makes it easy to understand.
+      - title: Neo4j
+        description: Neo4j is the world's leading graph database with native graph storage and processing, enabling an easy to understand approach to graph problems with its' Property graph model and Cypher query language.
         logos:
           - img: /assets/img/partners/neo4j.png
             url: http://www.neo4j.com
@@ -53,29 +53,29 @@ sections:
   - title: Industry Partners
     subsections:
       - title: T-Systems
-        description: T-Systems offers a Hadoop Cloud solution in Switzerland. With this solution companies can have a bare-metal Hadoop Cluster included in a PaaS offer, that enables next to an optimal connectivity to the client network also garanties that their data is only on their dedicated hardware in Switzerland. Scigility and T-Systems work closely together for the optimal application of this PaaS for you. 
+        description: T-Systems offers a Hadoop cloud solution in Switzerland, enabling companies to have a bare-metal Hadoop cluster included in a PaaS offer. This leads to an optimal connectivity to the client network and also guarantees that the customer data is only on dedicated hardware in Switzerland. Scigility and T-Systems work closely together for the optimal application of this PaaS. 
         logos:
           - img: /assets/img/partners/t-systems.png
             url: http://www.t-systems.com/ch/de
       - title: HP Enterprise
-        description: For over 75 years Hewlett Packard is active in the area of innovations. HP’s comprehensive portfolio is part of an innovation strategy, that has been developed in order to support organisations of very size - from the international conglomerate to the startup. Scigility and HP work together in order to enable and support clients with the optimal advancement of the digital transformation. 
+        description: Hewlett Packard has been active in the area of innovation for over 75 years. HP's comprehensive portfolio is part of an innovation strategy that has been developed in order to support organisations of every size - from international conglomerate to startup. Scigility and HP work together to enable and support clients optimally with their digital transformation. 
         logos:
           - img: /assets/img/partners/hpe.png
             url: http://www.hpe.com/de/de/home.html
       - title:  SAP
-        description: As one of the market leaders for enterprise software SAP supports companies and organisations with the minimizing of the negative impact complex systems can have, as well as creating new possibilities of innovation and growth in order to remain competitive. Scigility has specialized in the integration of SAP HANA and Hadoop environments. We work together with our SAP Partner SEC1.01.
+        description: As one of the market leaders for enterprise software, SAP supports companies and organisations with minimizing the negative impact of system complexity, as well as creating new possibilities of innovation and growth to remain competitive. Working together with partner SEC1.01, Scigility has specialized in the integration of SAP HANA and Hadoop environments.
         logos:
           - img: /assets/img/partners/sap.jpg
             url: http://www.sap.ch
           - img: /assets/img/partners/sec101.jpg
             url: http://www.sec101.ch
       - title:  Edorex
-        description: Edorex is a Swiss Solution Integrator. Together with Edorex, Scigility works on innovative, data driven solutions for our clients. 
+        description: Edorex is a Swiss solution integrator working together with Scigility to provide innovative and data driven solutions. 
         logos:
           - img: /assets/img/partners/edorex.png
             url: http://www.edorex.ch
       - title:  Teradata
-        description: Teradata offers end-to-end data warehousing services as well as solutions for big data analytics, with which you can become a data based company and raise your revenue, efficiency and create convincing client experiences. Scigility works together with Teradata in order to successfully integrate Hadoop, Teradata Data Warehouse and Teradata AsterData.
+        description: Teradata offers end-to-end data warehousing services as well as solutions for big data analytics, helping companies to become data driven, raising revenue and efficiency, and creating convincing client experiences. Scigility works together with Teradata in order to successfully integrate Hadoop, Teradata Data Warehouse and Teradata AsterData.
         logos:
           - img: /assets/img/partners/teradata.jpg
             url: http://www.teradata.ch
@@ -83,7 +83,7 @@ sections:
   - title: Acadamy and Research
     subsections:
       - title: Exascale Infolab
-        description: Scigility is convinced that in order to offer the best services to our clients, we need to work together with industry and academic partners. This is why we also contribute to research and the development of big data technologies. Scigility works with the eXascale Infolab on a daily basis, so that we always remain a competent partner with the newest technologies and methods.  
+        description: We are convinced that in order to offer the best services to our clients, we need to work together with both industry and academic partners – this is why we also contribute to research and the development of big data technologies. To also remain a competent partner with the newest technologies and methods in the future, we work together with the eXascale Infolab on a regular basis.
         logos:
           - img: /assets/img/partners/xi.jpg
             url: http://exascale.info


### PR DESCRIPTION
The partner page both in German and English contained some misspellings (capitalization and twisted/missing letters), grammatical errors and inconsistencies in formulation (e.g. switching from a "Scigility does" to "we do" from one sentence to another). This changes contained within this PR aim to solve and improve that.