### PR TITLE
Fix broken event dates

### DIFF
--- a/_news/gdpr-event-20180914.de.md
+++ b/_news/gdpr-event-20180914.de.md
@@ -35,7 +35,7 @@ After this event you will be aware of general methods and techniques how to prec
 
 
 ### Date
-14. September 2018
+September 14 2018
 
 ### Place
 Scigility AG, Europaallee 41, 8021 Zürich

--- a/_news/gdpr-event-20180914.en.md
+++ b/_news/gdpr-event-20180914.en.md
@@ -35,7 +35,7 @@ After this event you will be aware of general methods and techniques how to prec
 
 
 ### Date
-14. September 2018
+September 14 2018
 
 ### Place
 Scigility AG, Europaallee 41, 8021 Zürich

--- a/_news/sbdug-meetup-20190708.de.md
+++ b/_news/sbdug-meetup-20190708.de.md
@@ -27,7 +27,7 @@ Achtung: Sämtliche Talks werden auf Englisch präsentiert.
 
 
 ### Date
-8. Juli 2019
+8\. Juli 2019
 
 ### Place
 Scigility Switzerland AG, Europaallee 41, 8021 Zürich


### PR DESCRIPTION
A number followed by a dot is treated as an ordered list in Markdown, which is then published always as 1. on the website.

To circumvent this behaviour, dots have to be escaped with a backslash when writing a date.

**WRONG** example:
`17. April 2019` will be published on the website as `1. April 2019`

**CORRECT** example:
`17\. April 2019` will be published on the website as `17. April 2019`