### PR TITLE
Fix meta descriptions in English & German

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,8 +5,8 @@ title:
 #  fr: Scigility SA
 # HTML <head> description, good content means good SEO
 description:
-  de: Scigility ist der führende Big Data Spezialist in der Schweiz. Wir bieten Consulting, Data Science, Engineering, Trainint & Support und Legal Counsel an.
-  en: Scigility is a leading Big Data specialist solution provider. Offering Consulting, Data Science, Engineering, Training & Support and Legal Counsel.
+  de: Scigility ist der führende Big Data Spezialist in der Schweiz. Wir bieten Consulting, Data Science, Engineering, Training & Support und Legal Counsel an.
+  en: Scigility is Switzerland's leading big data specialist solution provider. We offer consulting, data science, engineering, training & support and legal counsel.
 #  fr: Blah blah
 
 defaultlanguage: "de"


### PR DESCRIPTION
The page meta descriptions prominently visible on search engines contain misspellings and capitalization errors, which are fixed with this PR.  